### PR TITLE
fix: `(helm-move-to-line-cycle-in-source . nil)`

### DIFF
--- a/init.el
+++ b/init.el
@@ -566,6 +566,8 @@ Emacs側でシェルを読み込む。"
   (helm-ff-file-name-history-use-recentf . t)
   ;; ウインドウ全体に表示
   (helm-full-frame . t)
+  ;; `helm-for-files'を多用するためソースは`helm-next-line'などで移動したい。
+  (helm-move-to-line-cycle-in-source . nil)
   :defvar helm-for-files-preferred-list
   :init
   (defun helm-for-files-prefer-recentf ()


### PR DESCRIPTION
[Change default settings of some user vars · emacs-helm/helm@a4380ca](https://github.com/emacs-helm/helm/commit/a4380caef3a9e4b1e8d11458852ab67ba9b4cf58) でデフォルトでは異なるソースを移動しなくなったのを元の挙動に戻す。