### PR TITLE
perf: lsp-modeの推奨するパフォーマンス設定に変更

### DIFF
--- a/early-init.el
+++ b/early-init.el
@@ -3,8 +3,11 @@
 ;; GCが発動するまでのメモリ制限を起動後即座に緩めます。
 ;; あまり大きな値を設定するとスループットは良くなりますが、
 ;; レイテンシで反応が悪くなります。
-;; しかし起動した後はgcmhに任せるので起動時は大きくとってGCを減らします。
-(setq gc-cons-threshold (* 2 1000 1000 1000))
+;; しかし起動した後はどうせgcmhに任せるので起動時は大きくとってGCを減らします。
+(setq gc-cons-threshold 1073741824) ; 1GB
+
+;; lsp-modeをplistモードでビルドします。
+(setenv "LSP_USE_PLISTS" "true")
 
 ;; GUIメニューを構築前に無効化します。
 (push '(menu-bar-lines . 0) default-frame-alist)

--- a/init.el
+++ b/init.el
@@ -506,7 +506,7 @@ Emacs側でシェルを読み込む。"
   (message-log-max . 100000)                  ; メッセージをたくさん残す
   (read-buffer-completion-ignore-case . t)    ; 大文字と小文字を区別しない バッファ名
   (read-file-name-completion-ignore-case . t) ; 大文字と小文字を区別しない ファイル名
-  (read-process-output-max . 1048576)         ; プロセスから一度に読み込む量を増やす
+  (read-process-output-max . 3145728)         ; プロセスから一度に読み込む量を増やす、3MB
   (ring-bell-function . #'ignore)             ; ビープ音を消す
   (scroll-conservatively . 1)                 ; 最下段までスクロールした時のカーソルの移動量を減らす
   (scroll-margin . 5))                        ; 最下段までスクロールしたという判定を伸ばす


### PR DESCRIPTION
基本的には、
[Performance - LSP Mode - LSP support for Emacs](https://emacs-lsp.github.io/lsp-mode/page/performance/) に従っている。
plistに設定するようにしたのが今回の大きな変更点。
私の所有しているマシン全てでメモリは多めにしているため、
メモリはある多めに使うように設定している。