### PR TITLE
fix: lsp-prismaの依存関係をこちらで明示的に指定する

### DIFF
--- a/init.el
+++ b/init.el
@@ -1907,6 +1907,7 @@ poetryなどの自動的なトラッキングを使わずにマニュアルで�
 
 (leaf prisma-mode
   :straight (prisma-mode :type git :host github :repo "pimeys/emacs-prisma-mode" :branch "main")
+  :after lsp-mode
   :hook (prisma-mode-hook . lsp))
 
 (leaf yarn-mode :ensure t)


### PR DESCRIPTION
リポジトリに更新がなくてPRも放置されていて改善が見込めないため、ワークアラウンドを行う。