### PR TITLE
fix: `forge-pull-when-forge-repo`の修正

### DIFF
--- a/init.el
+++ b/init.el
@@ -1036,7 +1036,7 @@ Forgeとかにも作成機能はあるが、レビュアーやラベルやProjec
     :init
     (defun forge-pull-when-forge-repo ()
       "forgeが設定されているリポジトリでは`forge-pull'を実行する。"
-      (when (forge-get-repository nil) (forge-pull)))
+      (when (forge-get-repository :tracked?) (forge-pull)))
     :advice (:after magit-pull forge-pull-when-forge-repo)
     :config
     (leaf sqlite3


### PR DESCRIPTION
前は`nil`でも動いた気がするのだが、forgeのトラッキングの仕組みが変わったようなので合わせる。