### PR TITLE
fix: WSLgで2回目以降の起動時にフォントサイズが変更されない問題を修正

### DIFF
--- a/init.el
+++ b/init.el
@@ -374,7 +374,7 @@ Emacs側でシェルを読み込む。"
       (set-fontset-font t '(#x1F000 . #x1FAFF) (font-spec :name "Noto Color Emoji") nil 'append)))
   ;; `frame-pixel-width'がフレーム作成後でないと実用的な値を返さないので、
   ;; 初期化後にフォントサイズを設定します。
-  (add-hook 'after-init-hook 'font-setup))
+  (add-hook 'after-init-hook 'font-setup t))
 
 ;; シンタックスハイライトをグローバルで有効化
 (leaf font-core :config (global-font-lock-mode 1))


### PR DESCRIPTION
`after-init-hook`で`x-wm-set-size-hint`の前に`font-setup`があったのが原因なので、
`depth`引数を指定して後ろに追加するように修正。
