### PR TITLE
feat: gitのcommit時のauto fillを有効化

### DIFF
--- a/init.el
+++ b/init.el
@@ -1017,8 +1017,6 @@ Forgeとかにも作成機能はあるが、レビュアーやラベルやProjec
     :defvar git-commit-mode-map
     :bind (:git-commit-mode-map ("M-z" . yas-insert-snippet-conventional-commits-type))
     :config
-    ;; コミットメッセージ編集画面での幅に基づく自動改行を無効化
-    (remove-hook 'git-commit-setup-hook 'git-commit-turn-on-auto-fill)
     (modify-coding-system-alist 'file "COMMIT_EDITMSG" 'utf-8-unix)
     (swap-set-key git-commit-mode-map '(("p" . "t") ("M-p" . "M-t"))))
   (leaf git-rebase


### PR DESCRIPTION
鬱陶しいので無効化していたが、
GitHubでの表示が崩れることは警戒するに値する。
これからは頑張って短くしていく。
