### PR TITLE
fix: `font-setup`を`window-setup-hook`で実行

### DIFF
--- a/init.el
+++ b/init.el
@@ -374,7 +374,7 @@ Emacs側でシェルを読み込む。"
       (set-fontset-font t '(#x1F000 . #x1FAFF) (font-spec :name "Noto Color Emoji") nil 'append)))
   ;; `frame-pixel-width'がフレーム作成後でないと実用的な値を返さないので、
   ;; 初期化後にフォントサイズを設定します。
-  (add-hook 'after-init-hook 'font-setup t))
+  (add-hook 'window-setup-hook 'font-setup))
 
 ;; シンタックスハイライトをグローバルで有効化
 (leaf font-core :config (global-font-lock-mode 1))


### PR DESCRIPTION
フレームサイズがこちらのほうが確定していることが多い。
何度か試した限りではフォントサイズが反映されない問題は発生しなかった。
