### PR TITLE
fix!: Copilot ChatのグローバルプロンプトからEmacsを利用しているという情報を削除

### DIFF
--- a/init.el
+++ b/init.el
@@ -805,12 +805,10 @@ Emacs側でシェルを読み込む。"
   ("C-; C-u" . copilot-chat-del-current-buffer)
   :defvar copilot-chat-prompt
   :init
-  (defconst
-    copilot-chat-prompt-emacs-japanese "The user works in Emacs. Please respond in Japanese."
-    "プロンプト: ユーザはエディタにEmacsを使っていて日本語での返答を望んでいる。")
+  (defconst copilot-chat-prompt-japanese "Please respond in Japanese.")
   (defun copilot-chat-set-japanese ()
     "日本語を使うように小さくプロンプトを再設定する。"
-    (setq copilot-chat-prompt copilot-chat-prompt-emacs-japanese))
+    (setq copilot-chat-prompt copilot-chat-prompt-japanese))
   :config
   (leaf copilot-chat-shell-maker
     :after copilot-chat


### PR DESCRIPTION
ノイズになり無駄にEmacs上で動かすための方法を提示してしまうため削除。
Neovimを利用しているというオリジナルのプロンプトは問題だが、
Emacsを利用しているという情報もまた不要。
