### PR TITLE
feat: コミットメッセージ編集画面での幅に基づく自動改行を無効化

### DIFF
--- a/init.el
+++ b/init.el
@@ -1004,6 +1004,8 @@ Forgeとかにも作成機能はあるが、レビュアーやラベルやProjec
     :defvar git-commit-mode-map
     :bind (:git-commit-mode-map ("M-z" . yas-insert-snippet-conventional-commits-type))
     :config
+    ;; コミットメッセージ編集画面での幅に基づく自動改行を無効化
+    (remove-hook 'git-commit-setup-hook 'git-commit-turn-on-auto-fill)
     (modify-coding-system-alist 'file "COMMIT_EDITMSG" 'utf-8-unix)
     (swap-set-key git-commit-mode-map '(("p" . "t") ("M-p" . "M-t"))))
   (leaf git-rebase


### PR DESCRIPTION
英語圏だと便利なのかもしれないが、
日本語圏で自動改行されるのは鬱陶しすぎた。
幅を気をつけるにしてもカラーで警告とかにするべきで、
自動改行にするべきではない。
