### PR TITLE
Revert "feat: `*typespec-lsp*`のようなバッファ名をhelmのバッファリストから除外する"

### DIFF
--- a/init.el
+++ b/init.el
@@ -628,7 +628,6 @@ Emacs側でシェルを読み込む。"
             "vc"
 
             ".+ls\\(::stderr\\)?"
-            ".+lsp\\(::stderr\\)?"
             "eslint\\(::stderr\\)?"
             "lsp-.+\\(::stderr\\)?"
             "marksman\\(::stderr\\)?"
@@ -1908,15 +1907,6 @@ poetryなどの自動的なトラッキングを使わずにマニュアルで�
   :config
   (dvorak-set-key-prog nxml-mode-map)
   (leaf smartparens :config (sp-local-pair 'nxml-mode "<" ">" :actions nil)))
-
-(leaf typespec-ts-mode
-  :load-path "/home/ncaq/Desktop/typespec-ts-mode/"
-  :require t lsp-mode
-  :defun typespec-ts-mode-grammar-install
-  :defvar lsp-language-id-configuration
-  :config
-  (typespec-ts-mode-grammar-install)
-  (add-to-list 'lsp-language-id-configuration '(typespec-ts-mode . "typespec")))
 
 ;; 起動終わりの処理
 


### PR DESCRIPTION
Reverts ncaq/.emacs.d#61
別途コミットするべきものをしていなかった。
revertを失敗した。
[Revert "feat: `*typespec-lsp*`のようなバッファ名をhelmのバッファリストから除外する" by ncaq · Pull Request #62 · ncaq/.emacs.d](https://github.com/ncaq/.emacs.d/pull/62)