### PR TITLE
feat: `*typespec-lsp*`のようなバッファ名をhelmのバッファリストから除外する

### DIFF
--- a/init.el
+++ b/init.el
@@ -628,6 +628,7 @@ Emacs側でシェルを読み込む。"
             "vc"
 
             ".+ls\\(::stderr\\)?"
+            ".+lsp\\(::stderr\\)?"
             "eslint\\(::stderr\\)?"
             "lsp-.+\\(::stderr\\)?"
             "marksman\\(::stderr\\)?"


### PR DESCRIPTION
graphqlにも該当。
