### PR TITLE
fix: `haskell-mode-buffer-apply-command`が定義されていない事態を確実に無くす

### DIFF
--- a/init.el
+++ b/init.el
@@ -1701,9 +1701,9 @@ Forgeとかにも作成機能はあるが、レビュアーやラベルやProjec
     :init
     (defun haskell-buffer-cabal-fmt ()
       (interactive)
+      (unless (fboundp 'haskell-mode-buffer-apply-command) (require 'haskell-commands))
       (haskell-mode-buffer-apply-command "cabal-fmt"))
     (defun haskell-cabal-mode-setup ()
-      (require 'haskell-commands)
       (add-hook 'before-save-hook 'haskell-buffer-cabal-fmt nil t))
     :hook (haskell-cabal-mode-hook . haskell-cabal-mode-setup)
     :bind


### PR DESCRIPTION
実際に呼ばれる寸前に検査して、
必要なら`require`する。
