### PR TITLE
feat: `helm-boring-buffer-regexp-list`に`Copilot-chat-list`を追加

### DIFF
--- a/init.el
+++ b/init.el
@@ -622,6 +622,7 @@ Emacs側でシェルを読み込む。"
     :config
     (mapc (lambda (regex) (add-to-list 'helm-boring-buffer-regexp-list (concat "^\\*" regex "\\*$")))
           '("Flycheck errors"
+            "Copilot-chat-list"
             "Flymake log"
             "WoMan-Log"
             "copilot events"


### PR DESCRIPTION
存在していることが分かっていても良いことはないのでノイズになる。
