### PR TITLE
fix: `copilot-chat-frontend-list`が非公開変数になったのに対応

### DIFF
--- a/init.el
+++ b/init.el
@@ -854,11 +854,9 @@ Emacs側でシェルを読み込む。"
     :custom
     (copilot-chat-frontend . 'shell-maker)
     :defun copilot-chat-shell-maker-init
-    :defvar copilot-chat-frontend-list
     ;; 各種init関数でプロンプトが再設定されてしまうため(orgやmarkdownを切り替えるためだろう)、adviceを使って毎回再設定する。
     :advice (:after copilot-chat-shell-maker-init copilot-chat-set-japanese)
     :config
-    (push '(shell-maker . copilot-chat-shell-maker-init) copilot-chat-frontend-list)
     (copilot-chat-shell-maker-init))
   ;; Gitコミットメッセージの編集開始時にGitHub Copilotによるコミットメッセージを挿入する。
   (add-hook 'git-commit-setup-hook 'copilot-chat-insert-commit-message))


### PR DESCRIPTION
`copilot-chat--frontend-list`になったようですが、
いじる必要性もなくなった気がするので設定コードを削除。
