### PR TITLE
feat: `copilot-chat-default-model`を`o3-mini`に設定

### DIFF
--- a/init.el
+++ b/init.el
@@ -844,7 +844,7 @@ Emacsでは`C-m'と`RET'を同一に扱うためうまく振り分けるのが�
 (leaf copilot-chat
   :ensure t
   :custom
-  (copilot-chat-default-model . "claude-3.5-sonnet")
+  (copilot-chat-default-model . "o3-mini")
   (copilot-chat-frontend . 'shell-maker)
   (copilot-chat-markdown-prompt . "Use Markdown for syntax. Please respond in Japanese.")
   :bind


### PR DESCRIPTION
o3-miniはGitのコミットメッセージ生成などで安定した性能を発揮するため。
それに先日発表されたGitHubの新しいプレミアムリクエストの料金表に対応したい。
とりあえずClaude 3.7がClaude 3.5と同じ価格でなので3.5を使う意味は特に無い。
ただClaude 3.7はコミットメッセージの生成などであまり安定していないので全面的に使うのはあまりやりたくない。
そしてo3-miniがかなり安いことが分かった。
なのでデフォルトではo3-miniを使いトークン量が多くo3-miniでは処理しきれない場合にClaude 3.7を使う運用にする。
