### PR TITLE
fix: cabal config load after itself

### DIFF
--- a/init.el
+++ b/init.el
@@ -1560,6 +1560,7 @@ Add the type signature that GHC infers to the function located below the point."
            ("C-c C-o" . lsp-haskell-execute-code-action-add-signature))))
 
 (leaf haskell-cabal
+  :after t
   :defun haskell-mode-buffer-apply-command
   :defvar haskell-cabal-mode-map
   :init


### PR DESCRIPTION
以下の警告を修正する。

```
⛔ Warning (leaf): Error in `haskell-cabal' block at `/home/ncaq/.emacs.d/init.el'.  Error msg: Symbol’s value as variable is void: haskell-cabal-mode-map
```
