### PR TITLE
fix: remove unnecessary :ensure keyword from lsp-marksman

### DIFF
--- a/init.el
+++ b/init.el
@@ -1610,7 +1610,7 @@ Add the type signature that GHC infers to the function located below the point."
      ("ts" . web-mode)
      ("tsx" . web-mode)
      ("zsh" . sh-mode)))
-  (leaf lsp-marksman :ensure :require t))
+  (leaf lsp-marksman :require t))
 
 ;;; OCaml
 


### PR DESCRIPTION
`lsp-markman`は`lsp-mode`のファイルであり、
パッケージではないため、
`:ensure`キーワードは不適切。
