### PR TITLE
refactor: remove unused lsp-format-buffer-on-save setup

### DIFF
--- a/init.el
+++ b/init.el
@@ -1225,17 +1225,7 @@ Forgeとかにも作成機能はあるが、レビュアーやラベルやProjec
   (lsp-file-watch-threshold . 10000)     ; 監視ファイル警告を緩める
   (lsp-imenu-sort-methods . '(position)) ; sortがデフォルトでは種類別になっている
   (lsp-warn-no-matched-clients . nil)    ; クライアントが見つからない時の警告を無効化
-  :defun lsp-code-actions-at-point lsp-register-client lsp-stdio-connection lsp:code-action-title make-lsp-client
-  :init
-  (defun lsp-format-buffer-on-save-setup ()
-    "保存する前にフォーマットする設定を有効にする。
-呼び出したバッファーでしか有効にならない。"
-    (add-hook 'before-save-hook #'lsp-format-buffer nil t))
-  ;; プロジェクト側が自動フォーマットを設定することを許可する。
-  (add-to-list 'safe-local-eval-forms '(add-hook 'before-save-hook #'project-format-buffer nil t))
-  (add-to-list 'safe-local-eval-forms '(defun project-format-buffer ()
-                                         (when (commandp #'lsp-format-buffer)
-                                           (lsp-format-buffer))))
+  :defun lsp-code-actions-at-point lsp:code-action-title
   ;; `prog-mode'を継承したモード全体でlsp-modeを有効にしてしまう。
   ;; 見つからない時の警告は`lsp-warn-no-matched-clients'で無効化。
   :hook ((prog-mode-hook markdown-mode-hook) . lsp-deferred)
@@ -1479,8 +1469,6 @@ Forgeとかにも作成機能はあるが、レビュアーやラベルやProjec
 
 (leaf elm-mode
   :ensure t
-  :hook
-  (elm-mode-hook . lsp-format-buffer-on-save-setup)
   :bind (:elm-mode-map
          ("C-c C-f" . nil)
          ;; elm-format-bufferの方はnpmのプロジェクト固有のelm-formatを検知しないのでlspを使います。
@@ -1780,8 +1768,6 @@ poetryなどの自動的なトラッキングを使わずにマニュアルで�
 
 (leaf scala-mode
   :ensure t
-  :hook
-  (scala-mode-hook . lsp-format-buffer-on-save-setup)
   :config
   (leaf lsp-metals :ensure t :require t)
   (leaf smartparens :config (sp-local-pair 'scala-mode "{" nil :post-handlers nil)))
@@ -1857,7 +1843,6 @@ poetryなどの自動的なトラッキングを使わずにマニュアルで�
 
 (leaf typespec-ts-another-mode
   :vc (:url "https://github.com/ncaq/typespec-ts-another-mode/")
-  :hook (typespec-ts-another-mode-hook . lsp-format-buffer-on-save-setup)
   :bind (:typespec-ts-another-mode-map
          ([remap indent-whole-buffer] . lsp-format-buffer)))
 


### PR DESCRIPTION
Remove the `lsp-format-buffer-on-save-setup` definition and associated `safe-local-evalforms`.
