### PR TITLE
feat: change github copilot chat default model and commit model

### DIFF
--- a/init.el
+++ b/init.el
@@ -845,7 +845,8 @@ Emacsでは`C-m'と`RET'を同一に扱うためうまく振り分けるのが�
 (leaf copilot-chat
   :ensure t
   :custom
-  (copilot-chat-default-model . "gpt-4.1")
+  (copilot-chat-default-model . "o4-mini")
+  (copilot-chat-commit-model . "gpt-4.1")
   (copilot-chat-frontend . 'shell-maker)
   (copilot-chat-markdown-prompt . "Use Markdown for syntax. Please respond in Japanese.")
   :bind


### PR DESCRIPTION
* `copilot-chat-default-model`: 賢さと速度のバランスを考慮して`o4-mini`
  * うまく答えられない場合は`o3`に切り替える運用予定
* `copilot-chat-commit-model`: コミットメッセージをそのまま採用することはどうせあまりないので速度重視で`gpt-4.1`を選択
