### PR TITLE
feat!: remove custom before-save formatting hook setup

### DIFF
--- a/init.el
+++ b/init.el
@@ -77,10 +77,6 @@ Emacs側でシェルを読み込む。"
 
 (leaf nix-mode
   :ensure t
-  :init
-  (defun nix-mode-setup ()
-    (add-hook 'before-save-hook #'nix-format-before-save nil t))
-  :hook (nix-mode-hook . nix-mode-setup)
   :bind
   (:nix-mode-map
    ([remap indent-whole-buffer] . nix-format-buffer)))


### PR DESCRIPTION
他人のコード上で誤爆しすぎ。
もう少し賢く`nix fmt`などにも対応させたら復活させる。
