### PR TITLE
fix!: drop hadolint

### DIFF
--- a/init.el
+++ b/init.el
@@ -1126,16 +1126,7 @@ Forgeとかにも作成機能はあるが、レビュアーやラベルやProjec
    (setf (cadr (aref tabulated-list-format 0)) 100))
  :hook (docker-image-mode-hook . docker-image-mode-setup))
 
-(leaf
- dockerfile-mode
- :ensure t
- :init
- (leaf
-  flycheck
-  :after t
-  (defun dockerfile-mode-hook-setup ()
-    (flycheck-add-next-checker 'lsp 'dockerfile-hadolint)))
- :hook (dockerfile-mode-hook . dockerfile-mode-hook-setup))
+(leaf dockerfile-mode :ensure t)
 
 (leaf docker-compose-mode :ensure t)
 


### PR DESCRIPTION
lsp-modeが`flycheck-add-mode`を使っているので、
ごちゃごちゃした方法を使わずに両方を初回起動時から有効にする方法が思いつかない。
よって一度削除しておく。
後で考えます。
