### PR TITLE
feat(copilot-chat): デフォルトモデルを"gemini-2.5-pro"に変更

### DIFF
--- a/init.el
+++ b/init.el
@@ -849,7 +849,7 @@ Emacsでは`C-m'と`RET'を同一に扱うためうまく振り分けるのが�
  copilot-chat
  :ensure t
  :custom
- (copilot-chat-default-model . "o4-mini")
+ (copilot-chat-default-model . "gemini-2.5-pro")
  (copilot-chat-commit-model . "gpt-4.1")
  (copilot-chat-frontend . 'shell-maker)
  (copilot-chat-markdown-prompt . "Use Markdown for syntax. Please respond in Japanese.")


### PR DESCRIPTION
最近o4-miniの性能が悪い気がする。
思い込みで間違ったことを言って、その原因を私のコードのせいにすることが多い。
正しければ別に問題は無いのだが。
試しにチャットの分はデフォルトモデルをGeminiに変更してみる。
