### PR TITLE
feat: `copilot-chat-markdown-prompt`を改善

### DIFF
--- a/init.el
+++ b/init.el
@@ -846,7 +846,7 @@ Emacsでは`C-m'と`RET'を同一に扱うためうまく振り分けるのが�
  (copilot-chat-default-model . "gpt-5")
  (copilot-chat-commit-model . "grok-code-fast-1")
  (copilot-chat-frontend . 'shell-maker)
- (copilot-chat-markdown-prompt . "Use Markdown for syntax. Please respond in Japanese.")
+ (copilot-chat-markdown-prompt . "日本語で答えてください。")
  :bind
  ("C-; C-;" . copilot-chat-display)
  ("C-; C-a" . copilot-chat-ask-and-insert)


### PR DESCRIPTION
Markdownで出力するのはデフォルトの挙動になりつつあるのでノイズになるので削除。
日本語指定は日本語で指示したほうが精度が高い気がするので英語ではなく日本語で書く。
