### PR TITLE
feat(magit): magit-diffでファイルを開く際にworktreeを優先する

### DIFF
--- a/init.el
+++ b/init.el
@@ -1055,6 +1055,7 @@ Forgeとかにも作成機能はあるが、レビュアーやラベルやProjec
  (leaf
   magit-diff
   :after t
+  :custom (magit-diff-visit-prefer-worktree . t)
   ;; `magit-diff-visit-worktree-file'は`C-<return>'でも代用出来て、検索の誤爆の原因になるので無効化する。
   :bind (:magit-diff-section-map ("C-j" . nil)))
  (leaf magit-pull :custom (magit-pull-or-fetch . t))


### PR DESCRIPTION
[How to make RET on staged file open the file on disk, not the .~(index)~ variant? · magit/magit · Discussion #5421](https://github.com/magit/magit/discussions/5421)
