### PR TITLE
feat(copilot-chat): commit message生成モデルをo4-miniに変更

### DIFF
--- a/init.el
+++ b/init.el
@@ -844,7 +844,7 @@ Emacsでは`C-m'と`RET'を同一に扱うためうまく振り分けるのが�
  :ensure t
  :custom
  (copilot-chat-default-model . "gpt-5")
- (copilot-chat-commit-model . "gemini-2.5-pro")
+ (copilot-chat-commit-model . "o4-mini")
  (copilot-chat-frontend . 'shell-maker)
  (copilot-chat-markdown-prompt . "日本語で答えてください。")
  :bind


### PR DESCRIPTION
geminiもコミットメッセージ生成としては結局しっくりこなかった。
