### PR TITLE
feat: コミットメッセージの生成にはGPT-4.1を使用する

### DIFF
--- a/init.el
+++ b/init.el
@@ -844,7 +844,7 @@ Emacsでは`C-m'と`RET'を同一に扱うためうまく振り分けるのが�
  :ensure t
  :custom
  (copilot-chat-default-model . "gpt-5")
- (copilot-chat-commit-model . "o4-mini")
+ (copilot-chat-commit-model . "gpt-4.1")
  (copilot-chat-frontend . 'shell-maker)
  (copilot-chat-markdown-prompt . "日本語で答えてください。")
  :bind


### PR DESCRIPTION
プレミアムリクエストの上限に達してしまったため。
o4-miniには応答速度にも課題があるので、
大人しく消費も安くて比較的高速なGPT-4.1を使用します。
