### PR TITLE
fix(rustic): safe-local-variableにrustic-indent-offsetを追加

### DIFF
--- a/init.el
+++ b/init.el
@@ -1784,7 +1784,8 @@ poetryなどの自動的なトラッキングを使わずにマニュアルで�
  :mode "\\.rs\\'"
  :custom (lsp-rust-analyzer-cargo-watch-command . "clippy")
  (rustic-format-display-method . 'ignore) ; Rustfmtのメッセージをポップアップしない
- (rustic-format-trigger . 'on-save))
+ (rustic-format-trigger . 'on-save)
+ :config (add-to-list 'safe-local-variable-values '(rustic-indent-offset . 4)))
 
 ;;; Scala
 


### PR DESCRIPTION
- プロジェクトローカルでrustic-indent-offsetの指定を許可
- 安全な値として4を追加することでローカル変数警告を防止
