### PR TITLE
feat(copilot-chat): change default model to gpt-5-codex

### DIFF
--- a/init.el
+++ b/init.el
@@ -843,7 +843,7 @@ Emacsでは`C-m'と`RET'を同一に扱うためうまく振り分けるのが�
  copilot-chat
  :ensure t
  :custom
- (copilot-chat-default-model . "gpt-5")
+ (copilot-chat-default-model . "gpt-5-codex")
  (copilot-chat-commit-model . "gpt-4.1")
  (copilot-chat-frontend . 'shell-maker)
  (copilot-chat-markdown-prompt . "日本語で答えてください。")


### PR DESCRIPTION
copilot-chat-default-modelを"gpt-5"から"gpt-5-codex"に変更。
