### PR TITLE
feat(copilot-chat): commitモデルをgpt-5-miniに更新

### DIFF
--- a/init.el
+++ b/init.el
@@ -844,7 +844,7 @@ Emacsでは`C-m'と`RET'を同一に扱うためうまく振り分けるのが�
  :ensure t
  :custom
  (copilot-chat-default-model . "gpt-5-codex")
- (copilot-chat-commit-model . "gpt-4.1")
+ (copilot-chat-commit-model . "gpt-5-mini")
  (copilot-chat-frontend . 'shell-maker)
  (copilot-chat-markdown-prompt . "日本語で答えてください。")
  :bind


### PR DESCRIPTION
同じGPT-5 miniはGPT-4.1と同じ0コストになったらしいので、
より賢いモデルに変更します。
時間はより掛かるかもしれませんが、
質を優先することにします。
