### PR TITLE
feat(copilot-chat): デフォルトモデルを gpt-5 に変更

### DIFF
--- a/init.el
+++ b/init.el
@@ -843,7 +843,7 @@ Emacsでは`C-m'と`RET'を同一に扱うためうまく振り分けるのが�
  copilot-chat
  :ensure t
  :custom
- (copilot-chat-default-model . "gpt-5-codex")
+ (copilot-chat-default-model . "gpt-5")
  (copilot-chat-commit-model . "gpt-5-mini")
  (copilot-chat-frontend . 'shell-maker)
  (copilot-chat-markdown-prompt . "日本語で答えてください。")


### PR DESCRIPTION
copilot-chat.elの方のエンドポイントが対応していないようです。
