### PR TITLE
feat(copilot): copilot-chat-commit-model を gpt-4.1 に変更

### DIFF
--- a/init.el
+++ b/init.el
@@ -844,7 +844,7 @@ Emacsでは`C-m'と`RET'を同一に扱うためうまく振り分けるのが�
  :ensure t
  :custom
  (copilot-chat-default-model . "gpt-5")
- (copilot-chat-commit-model . "gpt-5-mini")
+ (copilot-chat-commit-model . "gpt-4.1")
  (copilot-chat-frontend . 'shell-maker)
  (copilot-chat-markdown-prompt . "日本語で答えてください。")
  :bind


### PR DESCRIPTION
料金が同じだからGPT-5 miniを使ってみましたが、
コミットメッセージの雑生成をするためだけだと応答速度が遅すぎました。
