### PR TITLE
feat(copilot): update default chat model to gpt-5.1-codex-max

### DIFF
--- a/init.el
+++ b/init.el
@@ -843,7 +843,7 @@ Emacsでは`C-m'と`RET'を同一に扱うためうまく振り分けるのが�
  copilot-chat
  :ensure t
  :custom
- (copilot-chat-default-model . "gpt-5.1")
+ (copilot-chat-default-model . "gpt-5.1-codex-max")
  (copilot-chat-commit-model . "gpt-4.1")
  (copilot-chat-frontend . 'shell-maker)
  (copilot-chat-markdown-prompt . "日本語で答えてください。")


### PR DESCRIPTION
copilot-chat.elの更新でresponsesを使うcodex系モデルが使えるようになったので。
そんなにコストも変わらないようですし利用。
