### PR TITLE
fix(frame): デーモン起動時も新規フレームを最大化するよう修正

### DIFF
--- a/init.el
+++ b/init.el
@@ -512,7 +512,7 @@ Emacs側でシェルを読み込む。"
  (frame-maximized)
  ;; デーモンモードでは起動時にフレームが存在しないため、
  ;; `default-frame-alist'で新規フレーム作成時に最大化します。
- (push '(fullscreen . maximized) default-frame-alist))
+ (add-to-list 'default-frame-alist '(fullscreen . maximized)))
 
 (leaf image-file :global-minor-mode auto-image-file-mode)
 


### PR DESCRIPTION
- デーモンモードでは起動時にフレームが存在しないため
  default-frame-alistに'(fullscreen . maximized)を追加
- 通常起動時と同様に新規フレームも最大化されるよう統一
