### PR TITLE
fix: exec-path-from-shellを全てで利用

### DIFF
--- a/init.el
+++ b/init.el
@@ -78,10 +78,12 @@
 (leaf
  exec-path-from-shell
  :doc
- "Windowsのwslg.exeやmacOSのランチャーなどから起動したときはシェルの環境変数を引き継がないため、
-Emacs側でシェルを読み込む。"
+ "以下のようなシェルの環境変数を引き継がないケースでもEmacs側で環境変数を読み込みます。
+- Windowsのwslg.exe
+- macOSのランチャー
+- systemdのサービス
+"
  :ensure t
- :when (and window-system (or system-type-wsl (eq system-type 'darwin)))
  :config
  ;; wslg.exeでshell-typeをnoneにすると何故かここで新しいインスタンスが起動してループするため注意。
  (exec-path-from-shell-initialize))


### PR DESCRIPTION
GPGのSSH agentをMagit経由で読み込めなくなって環境変数が引き継がれなくなっていたことに気が付きました。
最近GNU/LinuxでもEmacsをsystemdのデーモンとして利用することになったからです。
exec-path-from-shellを全ての環境で利用することで解決します。
条件をどうしようか悩みましたが、
もともとLinuxネイティブで弾きたいだけだったので、
全てで起動してもおそらく問題はないはずです。
問題があったとしても問題が起きてから対処します。
