### PR TITLE
fix: lsp-modeのplistモードビルド環境変数を削除

### DIFF
--- a/early-init.el
+++ b/early-init.el
@@ -6,9 +6,6 @@
 ;; しかし起動した後はどうせgcmhに任せるので起動時は大きくとってGCを減らします。
 (setq gc-cons-threshold 1073741824) ; 1GB
 
-;; lsp-modeをplistモードでビルドします。
-(setenv "LSP_USE_PLISTS" "true")
-
 ;; GUIメニューを構築前に無効化します。
 (push '(menu-bar-lines . 0) default-frame-alist)
 (push '(tool-bar-lines . 0) default-frame-alist)


### PR DESCRIPTION
nixの方面でビルドするとデフォルトビルドの方になってしまうので。
カスタムしてまでplistモードに思い入れはないので、
単純に削除しました。

- LSP_USE_PLISTS環境変数の設定をearly-init.elから削除
- lsp-modeのビルド方式に依存しないよう初期化処理を簡素化
