### PR TITLE
feat: exec-path-from-shellの環境変数リストにssh関連変数を追加

### DIFF
--- a/init.el
+++ b/init.el
@@ -84,6 +84,7 @@
 - systemdのサービス
 "
  :ensure t
+ :custom (exec-path-from-shell-variables . '("PATH" "MANPATH" "SSH_ASKPASS" "SSH_AUTH_SOCK"))
  :config
  ;; wslg.exeでshell-typeをnoneにすると何故かここで新しいインスタンスが起動してループするため注意。
  (exec-path-from-shell-initialize))


### PR DESCRIPTION
gpg経由のsshエージェントを利用するようにしたい。
悪用かもしれませんが、
`PATH`を引き継ぎたいのとSSHの設定を引き継ぎたいのでやりたいことは共通しているので。
