### PR TITLE
feat: C/C++のLSPサーバーをcclsからclangdに変更

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,7 @@
                 [
                   bash-language-server
                   black
-                  ccls
+                  clang-tools
                   clojure-lsp
                   cmake-language-server
                   copilot-language-server

--- a/init.el
+++ b/init.el
@@ -1438,7 +1438,7 @@ Forgeとかにも作成機能はあるが、レビュアーやラベルやProjec
 
 ;;; C/C++
 
-(leaf cc-mode :after t :defvar c-mode-base-map :config (dvorak-set-key-prog c-mode-base-map) (leaf ccls :ensure t))
+(leaf cc-mode :after t :defvar c-mode-base-map :config (dvorak-set-key-prog c-mode-base-map))
 
 ;;; CSS
 


### PR DESCRIPTION
lsp-modeのデフォルトのC/C++ LSPサーバーはclangdなので、
`ccls`パッケージの読み込みを削除するだけで切り替わります。
clangdはLLVMプロジェクトの一部として活発にメンテナンスされており、
リファクタリング支援や最新C/C++仕様への追随で優位です。
