### PR TITLE
feat: elpyパッケージの削除

### DIFF
--- a/init.el
+++ b/init.el
@@ -1761,17 +1761,6 @@ Add the type signature that GHC infers to the function located below the point."
  :defvar python-shell-completion-native-disabled-interpreters python-shell-virtualenv-root
  :config
  (leaf
-  elpy
-  :ensure t
-  :defvar elpy-modules
-  :defun elpy-enable
-  :init (elpy-enable)
-  :custom
-  (elpy-rpc-python-command . "python3")
-  (elpy-formatter . 'black)
-  :bind (:elpy-mode-map ([remap elpy-doc] . lsp-ui-doc-show) ([remap indent-whole-buffer] . elpy-black-fix-code))
-  :config (setq elpy-modules (delq 'elpy-module-flymake elpy-modules)))
- (leaf
   python-isort
   :ensure t
   :custom (python-isort-arguments . '("--stdout" "--atomic" "--profile" "black" "-"))


### PR DESCRIPTION
最近はlspなどの発展により、
依存関係の解決などで割と特殊な処理をするelpyは必須ではなくなってきたと思ったので、
試験的に削除してみます。
Gitの履歴には残っているので戻したくなったらいつでも戻せますし。
