### PR TITLE
feat: 起動時のGC制限値を4GBに変更しコメントを整理

### DIFF
--- a/early-init.el
+++ b/early-init.el
@@ -1,16 +1,18 @@
 ;; -*- lexical-binding: t; -*-
 
 ;; GCが発動するまでのメモリ制限を起動後即座に緩めます。
-;; あまり大きな値を設定するとスループットは良くなりますが、
-;; レイテンシで反応が悪くなります。
-;; しかし起動した後はどうせgcmhに任せるので起動時は大きくとってGCを減らします。
-(setq gc-cons-threshold 1073741824) ; 1GB
+;; 大きな値を設定するとスループットは良くなります。
+;; ただしレイテンシは悪くなる可能性があります。
+;; しかし起動した後はgcmhパッケージの調整に任せるため、
+;; 起動後のレイテンシはそこまで心配しなくても構いません。
+;; よって最終的にgcmhパッケージが処理することを前提に、
+;; 起動速度を重視してスループット最優先で設定します。
+(setq gc-cons-threshold (* 4 1024 1024 1024)) ; 4GB
 
 ;; GUIメニューを構築前に無効化します。
 (push '(menu-bar-lines . 0) default-frame-alist)
 (push '(tool-bar-lines . 0) default-frame-alist)
 
 ;; Local Variables:
-;; fill-column: 120
 ;; flycheck-disabled-checkers: (emacs-lisp-checkdoc)
 ;; End:


### PR DESCRIPTION
- 起動時のgc-cons-thresholdを1GBから4GBに変更
- コメントをより明確に整理し、gcmhパッケージ前提の説明を追加
- `fill-column`はeditorconfigの値を引き継ぐのでここには記載しない
  - 前に乗り換えた時に書き換え忘れていました
