### PR TITLE
feat(font): デフォルトフォントサイズを横100文字基準に調整

### DIFF
--- a/init.el
+++ b/init.el
@@ -466,7 +466,7 @@
                        ;; フルHDと4Kを想定。
                        :height
                        (if (<= (frame-pixel-width) 1920)
-                           120
+                           130
                          130))
    (set-fontset-font t 'unicode (font-spec :name "FirgeNerd Console") nil 'append)
    (unless (eq system-type 'darwin)

--- a/init.el
+++ b/init.el
@@ -464,12 +464,14 @@
                        :family "FirgeNerd Console"
                        ;; 2画面分割でだいたい横100文字を表示できる、
                        ;; 出来るだけ大きめのフォントサイズにします。
-                       ;; フルHDと4Kを想定します。
+                       ;; フルHDと4K(144 dpi)を想定します。
                        :height
                        (if (<= (frame-pixel-width) 1920)
                            ;; フルHDで横100文字を表示できるギリギリのサイズ。
                            130
-                         130))
+                         ;; 4K(144 dpi)ならもう少し大きくしても余裕がありますが、
+                         ;; 縦幅もそれなりに取りたいので控えめなサイズ。
+                         150))
    (set-fontset-font t 'unicode (font-spec :name "FirgeNerd Console") nil 'append)
    (unless (eq system-type 'darwin)
      (set-fontset-font t '(#x1F000 . #x1FAFF) (font-spec :name "Noto Color Emoji") nil 'append)))

--- a/init.el
+++ b/init.el
@@ -462,10 +462,12 @@
  (defun font-setup ()
    (set-face-attribute 'default nil
                        :family "FirgeNerd Console"
-                       ;; 2画面分割でだいたい横100文字を表示できるフォントサイズにする。
-                       ;; フルHDと4Kを想定。
+                       ;; 2画面分割でだいたい横100文字を表示できる、
+                       ;; 出来るだけ大きめのフォントサイズにします。
+                       ;; フルHDと4Kを想定します。
                        :height
                        (if (<= (frame-pixel-width) 1920)
+                           ;; フルHDで横100文字を表示できるギリギリのサイズ。
                            130
                          130))
    (set-fontset-font t 'unicode (font-spec :name "FirgeNerd Console") nil 'append)

--- a/init.el
+++ b/init.el
@@ -462,7 +462,7 @@
  (defun font-setup ()
    (set-face-attribute 'default nil
                        :family "FirgeNerd Console"
-                       ;; 2画面分割でだいたい横120文字を表示できるフォントサイズにする。
+                       ;; 2画面分割でだいたい横100文字を表示できるフォントサイズにする。
                        ;; フルHDと4Kを想定。
                        :height
                        (if (<= (frame-pixel-width) 1920)


### PR DESCRIPTION
`font-setup`のデフォルトフォントサイズの基準を、
従来の横120文字表示から横100文字表示に変更します。

`fill-column`のデフォルトを100文字にしたことに合わせ、
2画面分割でだいたい横100文字を表示できる範囲で、
出来るだけ大きめのフォントサイズを採用する方針にしました。

具体的にはフルHD環境を130、
4K(144 dpi)環境を150に設定します。
4Kは余裕がありますが、
縦幅もそれなりに取りたいので控えめなサイズに留めています。

合わせて意図が伝わるようにコメントも整理しました。
