### PR TITLE
feat(markdown-mode): markdown-modeでprettierをデフォルト自動実行

### DIFF
--- a/init.el
+++ b/init.el
@@ -1849,7 +1849,8 @@ Add the type signature that GHC infers to the function located below the point."
  markdown-mode
  :ensure t
  :mode ("README\\.md\\'" . gfm-mode)
- :custom (markdown-fontify-code-blocks-natively . t)
+ :custom
+ (markdown-fontify-code-blocks-natively . t) ; コードブロックにシンタックスハイライトをつける。
  :bind (:markdown-mode-map ("C-c k" . markdown-insert-kbd))
  :defvar markdown-mode-map markdown-code-lang-modes
  :config (dvorak-set-key-prog markdown-mode-map)

--- a/init.el
+++ b/init.el
@@ -1851,6 +1851,7 @@ Add the type signature that GHC infers to the function located below the point."
  :mode ("README\\.md\\'" . gfm-mode)
  :custom
  (markdown-fontify-code-blocks-natively . t) ; コードブロックにシンタックスハイライトをつける。
+ :hook (markdown-mode-hook . prettier-toggle-setup)
  :bind (:markdown-mode-map ("C-c k" . markdown-insert-kbd))
  :defvar markdown-mode-map markdown-code-lang-modes
  :config (dvorak-set-key-prog markdown-mode-map)

--- a/init.el
+++ b/init.el
@@ -1849,7 +1849,7 @@ Add the type signature that GHC infers to the function located below the point."
  markdown-mode
  :ensure t
  :mode ("README\\.md\\'" . gfm-mode)
- :custom (markdown-fontify-code-blocks-natively . t) (markdown-hide-urls . nil)
+ :custom (markdown-fontify-code-blocks-natively . t)
  :bind (:markdown-mode-map ("C-c k" . markdown-insert-kbd))
  :defvar markdown-mode-map markdown-code-lang-modes
  :config (dvorak-set-key-prog markdown-mode-map)


### PR DESCRIPTION
`markdown-mode`で`prettier`をデフォルトで自動実行するようにします。
保存時に自動整形されることで、Markdownの記述スタイルを手間なく統一できます。

あわせて`:custom`の設定を整理します。
`markdown-fontify-code-blocks-natively`の意図をコメントで補足し、
デフォルトで`nil`の`markdown-hide-urls`の冗長な設定を削除して、
設定全体をスッキリとさせます。
