### PR TITLE
build(nix): nixpkgsを26.05にバージョンアップ

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,16 +43,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779796641,
-        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
+        "lastModified": 1780203844,
+        "narHash": "sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1+N6cArVE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "25f538306313eae3927264466c70d7001dcea1df",
+        "rev": "b51242d7d43689db2f3be91bd05d5b24fbb469c4",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "My Emacs config";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     flake-parts.url = "github:hercules-ci/flake-parts";
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
@@ -94,7 +94,6 @@
           nginx-language-server
           nil
           nixfmt
-          nodePackages.purescript-language-server
           ocamlPackages.ocaml-lsp
           ocamlformat
           omnisharp-roslyn


### PR DESCRIPTION
- nixpkgsの参照をnixos-25.11からnixos-26.05へ更新
- 依存パッケージのハッシュとリビジョンを最新化
- nodePackagesごと削除されたのでpurescript-language-serverの記述を削除
  - しばらく書く予定無いからそれで良いとしておきます