### PR TITLE
fix(input-method): mozcのhelperパスを自動検出するよう修正

### DIFF
--- a/init.el
+++ b/init.el
@@ -1388,7 +1388,8 @@ Forgeとかにも作成機能はあるが、レビュアーやラベルやProjec
  :require t
  :custom
  (default-input-method . "japanese-mozc-im")
- (mozc-candidate-style . 'echo-area))
+ (mozc-candidate-style . 'echo-area)
+ `(mozc-helper-program-name . ,(executable-find "mozc_emacs_helper")))
 
 ;;; 汎用プログラミング機能
 


### PR DESCRIPTION
- `mozc-helper-program-name`を`executable-find`で自動設定
- 環境ごとに`mozc_emacs_helper`のパスが異なる問題を解消
