### PR TITLE
fix(magit): commit時のデフォルトの`--verbose`を無効化

### DIFF
--- a/init.el
+++ b/init.el
@@ -1290,6 +1290,13 @@ Forgeとかにも作成機能はあるが、レビュアーやラベルやProjec
  (leaf magit-pull :custom (magit-pull-or-fetch . t))
  (leaf magit-wip :blackout t :custom (magit-wip-mode . t))
  (leaf
+  magit-commit
+  :after t
+  :config
+  ;; `magit-commit'はデフォルトで`--verbose'が有効。
+  ;; commitlintがdiff部分を誤検出するため無効化する。
+  (oset (get 'magit-commit 'transient--prefix) default-value nil))
+ (leaf
   git-commit
   :custom (git-commit-major-mode . #'markdown-mode)
   :init


### PR DESCRIPTION
`magit-commit`はmagit本体の`:value '("--verbose")`によって、
デフォルトで`--verbose`が有効になっています。
この状態だとコミットメッセージ編集バッファにdiffが挿入され、
commitlintがそのdiff部分をメッセージの一部として誤検出してしまいます。

そこで`magit-commit`のprefixの`default-value`スロットを`nil`に上書きして、
デフォルトの`--verbose`を無効化します。
prefixの定義そのものを書き換える形なので、
ユーザが後から`C-x C-s`で保存した引数とは共存できます。

close #345
