### PR TITLE
perf(flycheck): Haskellのネイティブcheckerを無効化して開く速度を改善

### DIFF
--- a/init.el
+++ b/init.el
@@ -1477,7 +1477,12 @@ Forgeとかにも作成機能はあるが、レビュアーやラベルやProjec
  :ensure t
  :global-minor-mode global-flycheck-mode
  :blackout t
- :custom (flycheck-display-errors-function . nil) ; Echoエリアにエラーを表示しない。
+ :custom
+ (flycheck-display-errors-function . nil) ; Echoエリアにエラーを表示しない。
+ ;; HaskellはLSP(HLS)が診断を提供するためネイティブcheckerは冗長。
+ ;; 有効なままだとバッファを開くたびにghc/hlint/stackの実行ファイル探索が走り、
+ ;; `.hs'を開くのが異様に遅くなるため無効化する。
+ (flycheck-disabled-checkers . '(haskell-ghc haskell-hlint haskell-stack-ghc))
  :bind
  (:flycheck-mode-map
   ("C-z" . flycheck-list-errors)


### PR DESCRIPTION
`.hs`ファイルを開くと他の言語に比べて目立って時間がかかる問題がありました。
プロファイラで調べたところ、
`find-file`後に遅延実行される`flycheck`の構文チェックが主因でした。
適用可能なHaskell用checkerである`haskell-ghc`/`haskell-hlint`/`haskell-stack-ghc`の実行ファイルを、
毎回`executable-find`でPATHから探索しており、
これがバッファ表示までの遅延になっていました。

HaskellはLSP(HLS)が診断を提供するため、
これらネイティブcheckerは冗長です。
そこで`flycheck-disabled-checkers`で無効化して、
バッファを開くたびの実行ファイル探索をなくしました。
これにより`.hs`を開く速度が大幅に改善されました。

close #360
