### PR TITLE
fix(nix): 起動時の`nixd-deployed-nixos-options-expr`未定義エラーを解消します

### DIFF
--- a/init.el
+++ b/init.el
@@ -1942,6 +1942,7 @@ Add the type signature that GHC infers to the function located below the point."
   (lsp-nix-nixd-nixpkgs-expr . "import <nixpkgs> { }")
   (lsp-nix-nixd-nixos-options-expr . nixd-deployed-nixos-options-expr)
   (lsp-nix-nixd-home-manager-options-expr . nixd-deployed-home-manager-options-expr)
+  :defvar lsp-clients ; lsp-modeによる定義。lsp-nixが読み込まれているときには読み込まれている。
   :config (setf (lsp--client-priority (gethash 'nixd-lsp lsp-clients)) 1)))
 
 ;;; OCaml

--- a/init.el
+++ b/init.el
@@ -1930,10 +1930,9 @@ Add the type signature that GHC infers to the function located below the point."
   :after t
   :preface
   (defconst nixd-deployed-nixos-options-expr
-    (format
-     "(builtins.getFlake %S).nixosConfigurations.%S.options"
-     (file-truename "/etc/nixos-flake")
-     (system-name))
+    (format "(builtins.getFlake %S).nixosConfigurations.%S.options"
+            (file-truename "/etc/nixos-flake")
+            (system-name))
     "nixdに渡す、このホストにデプロイされているNixOSのオプションを取得する式。")
   (defconst nixd-deployed-home-manager-options-expr
     (concat nixd-deployed-nixos-options-expr ".home-manager.users.type.getSubOptions []")

--- a/init.el
+++ b/init.el
@@ -1935,16 +1935,14 @@ Add the type signature that GHC infers to the function located below the point."
      (file-truename "/etc/nixos-flake")
      (system-name))
     "nixdに渡す、このホストにデプロイされているNixOSのオプションを取得する式。")
+  (defconst nixd-deployed-home-manager-options-expr
+    (concat nixd-deployed-nixos-options-expr ".home-manager.users.type.getSubOptions []")
+    "nixdに渡す、home-managerのオプションを取得する式。")
   :custom
   (lsp-nix-nixd-formatting-command . ["nixfmt"])
   (lsp-nix-nixd-nixpkgs-expr . "import <nixpkgs> { }")
-  ;; `:custom'のバッククォートはleafのマクロ展開時に評価されてしまい、
-  ;; `:preface'の定義がまだ実行されていないため使えない。
-  ;; `:custom*'は値をフォームのまま残すので実行時に評価される。
-  :custom*
-  ((lsp-nix-nixd-nixos-options-expr nixd-deployed-nixos-options-expr)
-   (lsp-nix-nixd-home-manager-options-expr
-    (concat nixd-deployed-nixos-options-expr ".home-manager.users.type.getSubOptions []")))
+  (lsp-nix-nixd-nixos-options-expr . nixd-deployed-nixos-options-expr)
+  (lsp-nix-nixd-home-manager-options-expr . nixd-deployed-home-manager-options-expr)
   :config (setf (lsp--client-priority (gethash 'nixd-lsp lsp-clients)) 1)))
 
 ;;; OCaml

--- a/init.el
+++ b/init.el
@@ -1924,22 +1924,27 @@ Add the type signature that GHC infers to the function located below the point."
 (leaf
  nix-mode
  :ensure t
- :preface
- (defconst nixd-deployed-nixos-options-expr
-   (format
-    "(builtins.getFlake %S).nixosConfigurations.%S.options"
-    (file-truename "/etc/nixos-flake")
-    (system-name)))
  :config
  (leaf
   lsp-nix
   :after t
+  :preface
+  (defconst nixd-deployed-nixos-options-expr
+    (format
+     "(builtins.getFlake %S).nixosConfigurations.%S.options"
+     (file-truename "/etc/nixos-flake")
+     (system-name))
+    "nixdに渡す、このホストにデプロイされているNixOSのオプションを取得する式。")
   :custom
   (lsp-nix-nixd-formatting-command . ["nixfmt"])
   (lsp-nix-nixd-nixpkgs-expr . "import <nixpkgs> { }")
-  `(lsp-nix-nixd-nixos-options-expr . ,nixd-deployed-nixos-options-expr)
-  `(lsp-nix-nixd-home-manager-options-expr
-    . ,(concat nixd-deployed-nixos-options-expr ".home-manager.users.type.getSubOptions []"))
+  ;; `:custom'のバッククォートはleafのマクロ展開時に評価されてしまい、
+  ;; `:preface'の定義がまだ実行されていないため使えない。
+  ;; `:custom*'は値をフォームのまま残すので実行時に評価される。
+  :custom*
+  ((lsp-nix-nixd-nixos-options-expr nixd-deployed-nixos-options-expr)
+   (lsp-nix-nixd-home-manager-options-expr
+    (concat nixd-deployed-nixos-options-expr ".home-manager.users.type.getSubOptions []")))
   :config (setf (lsp--client-priority (gethash 'nixd-lsp lsp-clients)) 1)))
 
 ;;; OCaml


### PR DESCRIPTION
leafは`:custom`に渡されたバッククォート付きのフォームを、
キーワードを展開する前の正規化段階で`eval`します。

そのため`:preface`で定義した`nixd-deployed-nixos-options-expr`はまだ実行されておらず、
起動時に`Eager macro-expansion failure: (void-variable nixd-deployed-nixos-options-expr)`が出ていました。

合わせて`:preface`も、
値を実際に使う`lsp-nix`のleafへ移動します。
