### PR TITLE
feat: F#の編集環境をfsharp-ts-modeに移行

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,8 +58,18 @@
         pkgs: epkgs:
         let
           # tree-sitterの文法一式。
-          treesitPackages = with epkgs; [
-            treesit-grammars.with-all-grammars
+          treesitPackages = [
+            (epkgs.treesit-grammars.with-grammars (
+              grammars:
+              pkgs.tree-sitter.allGrammars
+              ++ [
+                # nixpkgsは1リポジトリにつき1文法しかビルドしないため、
+                # `tree-sitter-fsharp`は`fsharp`文法だけが提供され、
+                # `.fsi`が使う`fsharp_signature`文法が欠けている。
+                # 同じソースから`language`を差し替えてビルドし直して補う。
+                (grammars.tree-sitter-fsharp.override { language = "fsharp_signature"; })
+              ]
+            ))
           ];
           # Emacs固有機能が利用するLanguage Server。
           languageServers = with pkgs; [

--- a/init.el
+++ b/init.el
@@ -1722,7 +1722,7 @@ PerlとPrologを自動識別するのは非常に有用です。"
  (leaf
   lsp-fsharp
   :custom
-  (lsp-fsharp-use-dotnet-tool-for-fsac . t))) ; nixで宣言的にインストールされていることが前提
+  (lsp-fsharp-use-dotnet-tool-for-fsac . nil))) ; nixで宣言的にインストールされていることが前提
 
 ;;; Haskell
 

--- a/init.el
+++ b/init.el
@@ -1522,7 +1522,7 @@ PerlとPrologを自動識別するのは非常に有用です。"
             ('emacslisp 'emacs-lisp-mode)
             ('erlang 'erlang-mode)
             ('fortran 'fortran-mode)
-            ('fsharp 'fsharp-mode)
+            ('fsharp 'fsharp-ts-mode)
             ('go 'go-mode)
             ('groovy 'groovy-mode)
             ('haskell 'haskell-ts-mode)
@@ -1708,6 +1708,16 @@ PerlとPrologを自動識別するのは非常に有用です。"
 ;;; Elm
 
 (leaf elm-mode :ensure t :bind (:elm-mode-map ("C-c C-f" . nil)))
+
+;;; F#
+
+(leaf
+ fsharp-ts-mode
+ :ensure t
+ :custom (fsharp-ts-guess-indent-offset . t)
+ :hook
+ (fsharp-ts-mode-hook . fsharp-ts-dotnet-mode)
+ (fsharp-ts-mode-hook . fsharp-ts-repl-minor-mode))
 
 ;;; Haskell
 

--- a/init.el
+++ b/init.el
@@ -1717,7 +1717,12 @@ PerlとPrologを自動識別するのは非常に有用です。"
  :custom (fsharp-ts-guess-indent-offset . t)
  :hook
  (fsharp-ts-mode-hook . fsharp-ts-dotnet-mode)
- (fsharp-ts-mode-hook . fsharp-ts-repl-minor-mode))
+ (fsharp-ts-mode-hook . fsharp-ts-repl-minor-mode)
+ :config
+ (leaf
+  lsp-fsharp
+  :custom
+  (lsp-fsharp-use-dotnet-local-tool . t))) ; nixで宣言的にインストールされてあることを前提にする。
 
 ;;; Haskell
 

--- a/init.el
+++ b/init.el
@@ -1722,7 +1722,7 @@ PerlとPrologを自動識別するのは非常に有用です。"
  (leaf
   lsp-fsharp
   :custom
-  (lsp-fsharp-use-dotnet-local-tool . t))) ; nixで宣言的にインストールされてあることを前提にする。
+  (lsp-fsharp-use-dotnet-tool-for-fsac . t))) ; nixで宣言的にインストールされていることが前提
 
 ;;; Haskell
 


### PR DESCRIPTION
F#の編集にtree-sitterベースの`fsharp-ts-mode`を使うようにします。
既存の`fsharp-mode`より構文解析が正確で、
補完やREPL連携も含めた推奨構成を整えられるためです。

LSPは既にlsp-modeを使っているため、
言語サーバをEmacsが対話的にインストールしようとするダイアログは無効化し、
Nixで宣言的に用意されたものを使う前提にしています。

またnixpkgsは1リポジトリにつき1文法しかビルドしないため、
`.fsi`ファイルが必要とする`fsharp_signature`の文法が欠けています。
同じソースから`language`を差し替えてビルドし直すワークアラウンドで補っています。
